### PR TITLE
Updated file format to address missing parameter issue

### DIFF
--- a/rackhd/centos_workflow.json
+++ b/rackhd/centos_workflow.json
@@ -1,33 +1,43 @@
 {
-	"friendlyName": "VirtualBox Default Install CentOS",
-	"injectableName": "Graph.DefaultVirtualBox.InstallCentOS",
-	"tasks": [{
-		"label": "create-noop-obm-settings",
-		"taskDefinition": {
-			"friendlyName": "Create VirtualBox OBM settings",
-			"injectableName": "Task.Obm.Vbox.CreateSettings",
-			"implementsTask": "Task.Base.Obm.CreateSettings",
-			"options": {
-				"service": "noop-obm-service",
-				"config": {}
-			},
-			"properties": {
-				"obm": {
-					"type": "virtualbox"
-				}
-			}
-		}
-	}, {
-		"label": "install-centos",
-		"taskName": "Task.Os.Install.CentOS",
-		"options": {
-			"repo": "{{api.server}}/Centos/7.0",
+  "friendlyName": "VirtualBox Default Install CentOS",
+  "injectableName": "Graph.DefaultVirtualBox.InstallCentOS",
+  "options": {
+    "defaults": {
+      "version": null,
+      "repo": "{{api.server}}/Centos/7.0",
 			"rootPassword": "root",
 			"users": [{
 				"name": "rackhd",
 				"password": "rackhd123",
 				"uid": 1010
 			}]
-		}
-	}]
+      },
+    "install-centos": {
+      "schedulerOverrides": {
+        "timeout": 3600000
+      }
+    }
+  },
+  "tasks": [
+    {
+      "label": "create-noop-obm-settings",
+      "taskDefinition": {
+        "friendlyName": "Create VirtualBox No-Op OBM settings",
+        "injectableName": "Task.Obm.Vbox.Noop.CreateSettings",
+        "implementsTask": "Task.Base.Obm.CreateSettings",
+        "options": {
+        "service": "noop-obm-service",
+        "config": {}
+        },
+        "properties": {
+        "obm": {
+            "type": "virtualbox"
+        }
+      }}
+    },
+    {
+      "label": "install-centos",
+      "taskName": "Task.Os.Install.CentOS"
+    }
+  ]
 }


### PR DESCRIPTION
Issue in current file format raised an error of 'missing options.version' variable when node attempts to run workflow. Shifting options from task element from os provisioning into parent fixes the problem.
